### PR TITLE
Add high quality finetuning

### DIFF
--- a/configs/high_quality_finetune.yaml
+++ b/configs/high_quality_finetune.yaml
@@ -9,7 +9,7 @@ train_data:
   preprocessed: True
   n_sample_frames: 1
   shuffle_frames: False
-  width: 384      
+  width: 512      
   height: 320
   sample_start_idx: 0
   sample_frame_rate: 8
@@ -22,7 +22,7 @@ validation_data:
   prompt: ""
   sample_preview: True
   num_frames: 16
-  width: 384
+  width: 512
   height: 320
   num_inference_steps: 50
   guidance_scale: 9

--- a/configs/high_quality_finetune.yaml
+++ b/configs/high_quality_finetune.yaml
@@ -33,7 +33,7 @@ train_batch_size: 1
 max_train_steps: 50000
 checkpointing_steps: 2500
 validation_steps: 200
-unfreeze_temp: True
+unfreeze_temp: False
 trainable_modules:
   - "to_q"
   - "to_k"

--- a/configs/high_quality_finetune.yaml
+++ b/configs/high_quality_finetune.yaml
@@ -1,0 +1,50 @@
+pretrained_model_path: "./models/model_scope_diffusers/" #https://huggingface.co/damo-vilab/text-to-video-ms-1.7b/tree/main
+output_dir: "./outputs"
+train_text_encoder: False
+offset_noise_strength: 0.1
+use_offset_noise: True
+
+train_data:
+  json_path: "./json/train.json"
+  preprocessed: True
+  n_sample_frames: 1
+  shuffle_frames: False
+  width: 384      
+  height: 320
+  sample_start_idx: 0
+  sample_frame_rate: 8
+  vid_data_key: "video_path"
+
+  single_video_path: ""
+  single_video_prompt: ""
+
+validation_data:
+  prompt: ""
+  sample_preview: True
+  num_frames: 16
+  width: 384
+  height: 320
+  num_inference_steps: 50
+  guidance_scale: 9
+
+learning_rate: 1e-5
+adam_weight_decay: 1e-2
+train_batch_size: 1
+max_train_steps: 50000
+checkpointing_steps: 2500
+validation_steps: 200
+unfreeze_temp: True
+trainable_modules:
+  - "to_q"
+  - "to_k"
+  - "to_v"
+  - "to_out"
+  - "proj_in"
+  - "proj_out"
+
+seed: 64
+mixed_precision: "fp16"
+use_8bit_adam: False # This seems to be incompatible at the moment. 
+
+# Xformers must be installed
+enable_xformers_memory_efficient_attention: True

--- a/configs/my_config.yaml
+++ b/configs/my_config.yaml
@@ -9,7 +9,7 @@ train_data:
   width: 256      
   height: 256
   sample_start_idx: 0
-  sample_frame_rate: 15
+  sample_frame_rate: 8
   use_random_start_idx: False
   vid_data_key: "video_path"
 

--- a/configs/my_config_hq.yaml
+++ b/configs/my_config_hq.yaml
@@ -10,7 +10,7 @@ train_data:
   width: 384      
   height: 256
   sample_start_idx: 0
-  sample_frame_rate: 30
+  sample_frame_rate: 8
   vid_data_key: "video_path"
 
   single_video_path: ""

--- a/configs/offset_noise_finetune.yaml
+++ b/configs/offset_noise_finetune.yaml
@@ -12,7 +12,7 @@ train_data:
   width: 384      
   height: 256
   sample_start_idx: 0
-  sample_frame_rate: 30
+  sample_frame_rate: 8
   vid_data_key: "video_path"
 
   single_video_path: ""

--- a/configs/single_video_config.yaml
+++ b/configs/single_video_config.yaml
@@ -9,7 +9,7 @@ train_data:
   width: 256      
   height: 256
   sample_start_idx: 0
-  sample_frame_rate: 15
+  sample_frame_rate: 8
   use_random_start_idx: True
   vid_data_key: "video_path"
   

--- a/train.py
+++ b/train.py
@@ -36,6 +36,7 @@ from utils.dataset import VideoDataset
 from einops import rearrange, repeat
 
 already_printed_unet = False
+already_unfrozen = False
 
 # Will error if the minimal version of diffusers is not installed. Remove at your own risks.
 check_min_version("0.10.0.dev0")


### PR DESCRIPTION
We can enable fine-tuning at higher resolutions by only fine tuning the non-temporal layers of the model and using one or a few frames from the model.

This is similar to image pretraining when a 3D unet is agnostic to space and time, but since it isn't here, we can just fine tune on just a single video frame. This also opens up the possibility to just fine tune on images alone by adding a frame dimension like so:

Image: `b c h w`
Image as frame: `b c f h w`

This does leave it up to the model to _"figure out"_ what the temporal information is of the new data, but it's very much possible to pretrain the temporal information first at a lower resolution, then finetune on images afterwards at a higher resolution.

- [x] Create a config for training at higher resolutions
- [x] Create function for freezing or unfreezing temporal layers
- [ ] Test if we can pretrain on temporal layers first at 256x256, then train non temporal layers at higher resolutions to add new temporal data
- [ ] Can we use multiple frames on non temporal layers for improved coherency? I don't know the full details of the model, so need to test this.   