### PR TITLE
Add video folder dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+text-to-video-ms-1.7b/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/configs/video_folder.yaml
+++ b/configs/video_folder.yaml
@@ -1,0 +1,38 @@
+pretrained_model_path: "./text-to-video-ms-1.7b/"
+output_dir: "./output"
+train_text_encoder: False
+
+train_data:
+  type: folder
+  path: "path/to/folder/of/videos/"
+  n_sample_frames: 16
+  width: 256
+  height: 256
+  fps: 24
+  fallback_prompt: ""  # used when a video doesn't have a corresponding .txt file with a prompt
+
+validation_data:
+  prompt: ""
+  sample_preview: True
+  num_frames: 48
+  width: 256
+  height: 256
+  num_inference_steps: 50
+  guidance_scale: 9
+
+learning_rate: 1e-5
+adam_weight_decay: 1e-2
+train_batch_size: 1
+max_train_steps: 50000
+checkpointing_steps: 5000
+validation_steps: 500
+trainable_modules:
+  - "attn1"
+  - "attn2"
+  - "attn3"
+seed: 1234
+mixed_precision: "fp16"
+use_8bit_adam: False # This seems to be incompatible at the moment. 
+gradient_checkpointing: True
+enable_xformers_memory_efficient_attention: False
+enable_torch_2_attn: True

--- a/train.py
+++ b/train.py
@@ -25,7 +25,7 @@ from accelerate import Accelerator
 from accelerate.logging import get_logger
 from accelerate.utils import set_seed
 
-from .models.unet_3d_condition import UNet3DConditionModel
+from models.unet_3d_condition import UNet3DConditionModel
 from diffusers.models import AutoencoderKL
 from diffusers import DPMSolverMultistepScheduler, DDPMScheduler, TextToVideoSDPipeline
 from diffusers.optimization import get_scheduler

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -211,6 +211,7 @@ class VideoFolderDataset(Dataset):
         fps: int = 8,
         path: str = "./data",
         fallback_prompt: str = "",
+        **kwargs
     ):
         self.tokenizer = tokenizer
 


### PR DESCRIPTION
I've added a Dataset class which loads from a folder of MP4 files.

I'm not quite sure I understand what the other Dataset does in terms of frame-rate, but this one loads frames in so that all samples shown to the model will have the same FPS. In my experiments, using this strategy with high frame-rate videos really helps temporal consistency.

Prompts for each video can be specified as a .txt file with the same name as the video. Alternatively, the config supports a fallback prompt that'll be used if no .txt file exists (see `configs/video_folder.yaml`).