### PR TITLE
Add InfiNet module for DiffusionOverDiffusion training to allow for extremely (minutes!) long video creation

### DIFF
--- a/configs/my_config.yaml
+++ b/configs/my_config.yaml
@@ -34,6 +34,7 @@ validation_steps: 100
 trainable_modules:
   - "attn1.to_out"
   - "attn2.to_out"
+  - "infinet"
 seed: 64
 mixed_precision: "fp16"
 use_8bit_adam: False # This seems to be incompatible at the moment. 

--- a/eval.py
+++ b/eval.py
@@ -1,0 +1,213 @@
+import argparse
+import datetime
+import logging
+import inspect
+import math
+import os
+import random
+import gc
+import subprocess
+import tempfile
+
+from typing import Dict, Optional, Tuple, List
+
+import numpy as np
+from omegaconf import OmegaConf
+
+import torch
+import torch.nn.functional as F
+import torch.utils.checkpoint
+import torchvision.transforms as T
+import diffusers
+import transformers
+
+from pkg_resources import resource_filename
+from torchvision import transforms
+from tqdm.auto import tqdm
+
+from accelerate import Accelerator
+from accelerate.logging import get_logger
+from accelerate.utils import set_seed
+
+from models.unet_3d_condition import UNet3DConditionModel
+from diffusers.models import AutoencoderKL
+from diffusers import DPMSolverMultistepScheduler, DDPMScheduler, TextToVideoSDPipeline
+from diffusers.optimization import get_scheduler
+from diffusers.utils import check_min_version
+from diffusers.utils.import_utils import is_xformers_available
+from diffusers.models.attention_processor import AttnProcessor2_0, Attention
+from diffusers.models.attention import BasicTransformerBlock
+
+from transformers import CLIPTextModel, CLIPTokenizer
+from utils.dataset import VideoDataset
+from einops import rearrange, repeat
+
+already_printed_unet = False
+
+# Will error if the minimal version of diffusers is not installed. Remove at your own risks.
+check_min_version("0.10.0.dev0")
+
+logger = get_logger(__name__, log_level="INFO")
+
+
+def create_logging(logging, logger, accelerator):
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+        datefmt="%m/%d/%Y %H:%M:%S",
+        level=logging.INFO,
+    )
+    logger.info(accelerator.state, main_process_only=False)
+
+
+def accelerate_set_verbose(accelerator):
+    if accelerator.is_local_main_process:
+        transformers.utils.logging.set_verbosity_warning()
+        diffusers.utils.logging.set_verbosity_info()
+    else:
+        transformers.utils.logging.set_verbosity_error()
+        diffusers.utils.logging.set_verbosity_error()
+
+
+def create_output_folders(output_dir, config):
+    now = datetime.datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+    out_dir = os.path.join(output_dir, f"train_{now}")
+
+    os.makedirs(out_dir, exist_ok=True)
+    os.makedirs(f"{out_dir}/samples", exist_ok=True)
+    OmegaConf.save(config, os.path.join(out_dir, 'config.yaml'))
+
+    return out_dir
+
+
+def load_primary_models(pretrained_model_path):
+    noise_scheduler = DDPMScheduler.from_pretrained(pretrained_model_path, subfolder="scheduler")
+    tokenizer = CLIPTokenizer.from_pretrained(pretrained_model_path, subfolder="tokenizer")
+    text_encoder = CLIPTextModel.from_pretrained(pretrained_model_path, subfolder="text_encoder")
+    vae = AutoencoderKL.from_pretrained(pretrained_model_path, subfolder="vae")
+
+    unet = UNet3DConditionModel()
+
+    model_path = os.path.join(os.getcwd(), pretrained_model_path, 'unet', 'diffusion_pytorch_model.bin')
+    # Load the pretrained weights
+    pretrained_dict = torch.load(
+        model_path,
+        map_location=torch.device('cuda'),
+    )
+    unet.load_state_dict(pretrained_dict, strict=False)
+
+    unet.infinet._init_weights()
+
+    unet.infinet.diffusion_depth = 1
+    #unet = UNet3DConditionModel.from_pretrained(pretrained_model_path, subfolder="unet")
+
+    return noise_scheduler, tokenizer, text_encoder, vae, unet
+
+
+def main():
+    pretrained_model_path = "models/model_scope_diffusers"
+    # Load scheduler, tokenizer and models.
+    noise_scheduler, tokenizer, text_encoder, vae, unet = load_primary_models(pretrained_model_path)
+
+    vae.to("cuda")
+    unet.to("cuda")
+    text_encoder.to("cuda")
+
+    # Enable VAE slicing to save memory.
+    vae.enable_slicing()
+
+
+    #unet.eval()
+    #text_encoder.eval()
+
+    pipeline = TextToVideoSDPipeline.from_pretrained(
+        pretrained_model_path,
+        text_encoder=text_encoder,
+        vae=vae,
+        unet=unet
+    )
+
+    pipeline.enable_xformers_memory_efficient_attention()
+
+    diffusion_scheduler = DPMSolverMultistepScheduler.from_config(pipeline.scheduler.config)
+    pipeline.scheduler = diffusion_scheduler
+
+    prompt = "Couple walking on the beach"
+    os.makedirs("samples", exist_ok=True)
+    out_file = f"samples/eval_{prompt}.mp4"
+
+    with torch.no_grad():
+        video_frames = pipeline(
+            prompt,
+            width=512,
+            height=384,
+            num_frames=20,
+            num_inference_steps=50,
+            guidance_scale=7.5
+        ).frames
+    video_path = export_to_video(video_frames, out_file)
+
+    del pipeline
+    gc.collect()
+
+from PIL import Image
+import cv2
+def export_to_video(video_frames: List[np.ndarray], output_video_path: str = None, fps: int = 8) -> str:
+    if output_video_path is None:
+        output_video_path = tempfile.NamedTemporaryFile(suffix=".mp4").name
+
+    #fps = 8
+    h, w, c = video_frames[0].shape
+
+    os.makedirs(os.path.join(os.getcwd(), 'out'), exist_ok=True)
+    for i in range(len(video_frames)):
+#        Image.fromarray(video_frames[i]).save(os.path.join(os.getcwd(), 'out', f"frame_{i}.png"))
+        cv2.imwrite(os.path.join(os.getcwd(), 'out',
+                    f"{i:06}.png"), video_frames[i])
+
+    # create a pipe for ffmpeg to write the video frames to
+    ffmpeg_pipe = subprocess.Popen(
+        [
+            "ffmpeg",
+            "-y",  # overwrite output file if it already exists
+            "-f", "rawvideo",
+            "-pix_fmt", "rgb24",
+            "-s", f"{w}x{h}",
+            "-r", str(fps),
+            "-i", "-",
+            "-vcodec", "libx264",
+            "-preset", "medium",
+            "-crf", "23",
+            output_video_path,
+        ],
+        stdin=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    # write each video frame to the ffmpeg pipe
+    for frame in video_frames:
+        ffmpeg_pipe.stdin.write(frame.tobytes())
+
+    # close the ffmpeg pipe and wait for it to finish writing the video file
+    ffmpeg_pipe.stdin.close()
+    ffmpeg_pipe.wait()
+
+    return output_video_path
+
+if __name__ == "__main__":
+    main()
+
+def find_ffmpeg_binary():
+    try:
+        import google.colab
+        return 'ffmpeg'
+    except:
+        pass
+    for package in ['imageio_ffmpeg', 'imageio-ffmpeg']:
+        try:
+            package_path = resource_filename(package, 'binaries')
+            files = [os.path.join(package_path, f) for f in os.listdir(
+                package_path) if f.startswith("ffmpeg-")]
+            files.sort(key=lambda x: os.path.getmtime(x), reverse=True)
+            return files[0] if files else 'ffmpeg'
+        except:
+            return 'ffmpeg'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ accelerate
 torch
 torchvision
 torchaudio
+imageio_ffmpeg
 git+https://github.com/huggingface/diffusers.git
 transformers
 einops

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -26,6 +26,7 @@ class VideoDataset(Dataset):
             preprocessed: bool = False,
             single_video_path: str = "",
             single_video_prompt: str = "",
+            train_infinet = False,
             **kwargs
     ):
 
@@ -48,6 +49,8 @@ class VideoDataset(Dataset):
         self.sample_start_idx = sample_start_idx
         self.sample_frame_rate = sample_frame_rate
         self.sample_frame_rate_init = sample_frame_rate
+
+        self.train_infinet = train_infinet
 
     def load_from_json(self, path):
         # Don't load a JSON file if we're doing single video training
@@ -107,7 +110,7 @@ class VideoDataset(Dataset):
         
     def get_vid_idx(self, vr, vid_data=None):
 
-        if self.use_random_start_idx and self.n_sample_frames == 1:
+        if self.use_random_start_idx and self.n_sample_frames == 1 and not self.train_infinet:
             
             # Randomize the frame rate at different speeds
             self.sample_frame_rate = random.randint(1, self.sample_frame_rate_init)
@@ -119,6 +122,7 @@ class VideoDataset(Dataset):
             idx = random.randint(1, max_frame)
             
         else:
+
             if vid_data is not None:
                 idx = vid_data['frame_index']
             else:
@@ -187,6 +191,9 @@ class VideoDataset(Dataset):
             # Get video prompt
             prompt = vid_data['prompt']
 
+            # Get diffusion depth for training Infinet
+            diffusion_depth = vid_data['diffusion_depth'] if 'diffusion_depth' in vid_data.keys() else 0
+
             video = vr.get_batch(sample_index)
             video = rearrange(video, "f h w c -> f c h w")
 
@@ -195,7 +202,8 @@ class VideoDataset(Dataset):
         example = {
             "pixel_values": (video / 127.5 - 1.0),
             "prompt_ids": prompt_ids[0],
-            "text_prompt": prompt
+            "text_prompt": prompt,
+            "diffusion_depth": diffusion_depth,
         }
 
         return example


### PR DESCRIPTION
Hi, Exponential-ML!

As you probably know, a bit more than a week ago, Microsoft published their paper where they described the novel DiffusionOverDiffusion technique https://arxiv.org/abs/2303.12346 working by firstly outlining the coarse keyframes and then picking a pair of them as starting points and filling in-betweens (with different, more local prompts!)

![image](https://user-images.githubusercontent.com/14872007/229348405-0276b587-4c45-41dc-ac95-f994827108ac.png)

Using it they were able to tune on and create whole 11 minutes long Flintstones episodes https://www.reddit.com/r/StableDiffusion/comments/11zwaxx/microsofts_nuwaxl_creates_an_11_minute/

Seeing their impressive results, I couldn't have restrained myself from trying to replicate them.

Having read the article, I noticed that the model structure is extremely similar to the ModelScope one, and the only difference is the 'video conditioning' layer (in green), which information is being transferred into the preexisting U-net3D by a set of Conv-down cells.

![image](https://user-images.githubusercontent.com/14872007/229348652-8590640f-734f-4348-86aa-1f853f27243b.png)

Thanks to them using so called *zero-convolutions* I realized that layer as a ControlNet-like network https://github.com/kabachuha/InfiNet, with which it is possible to introduce the new layers without altering the work of the existing model. (See `DoDBlock` in the code)

![image](https://user-images.githubusercontent.com/14872007/229348789-0f684d56-ac68-471a-a069-00308e90db8f.png)

I already tested the inference with `diffusion_depth=0` and `diffusion_depth=1` (any `diffusion_depth>0` turns on the DoD-blocks), so when inferring the model definitely works

I'll start training experiments as soon as I'll figure out the dataset and the system requirements for it