### PR TITLE
Same device tensors

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -112,7 +112,7 @@ def encode(pipe: TextToVideoSDPipeline, pixels: Tensor, batch_size: int = 8):
     ):
         pixels_batch = pixels[idx : idx + batch_size].to(pipe.device, dtype=torch.half)
         latents_batch = pipe.vae.encode(pixels_batch).latent_dist.sample()
-        latents_batch = latents_batch.mul(pipe.vae.config.scaling_factor).cpu()
+        latents_batch = latents_batch.mul(pipe.vae.config.scaling_factor).to(pipe.device)
         latents.append(latents_batch)
     latents = torch.cat(latents)
 


### PR DESCRIPTION
Ran into the following issue when running inference with an init_video:

```
Encoding to latents...: 100%|████████████████| 24/24 [00:03<00:00,  7.63frame/s]
Diffusing timestep 240...:   0%|                          | 0/6 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "/content/Text-To-Video-Finetuning/inference.py", line 396, in <module>
    videos = inference(
  File "/usr/local/lib/python3.10/dist-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/content/Text-To-Video-Finetuning/inference.py", line 316, in inference
    latents = diffuse(
  File "/usr/local/lib/python3.10/dist-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/content/Text-To-Video-Finetuning/inference.py", line 230, in diffuse
    noise_pred = pipe.unet(latent_model_input, t, encoder_hidden_states=prompt_embeds).sample
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/diffusers/models/unet_3d_condition.py", line 520, in forward
    emb = self.time_embedding(t_emb, timestep_cond)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/diffusers/models/embeddings.py", line 192, in forward
    sample = self.linear_1(sample)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/linear.py", line 114, in forward
    return F.linear(input, self.weight, self.bias)
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument mat1 in method wrapper_addmm)
```

Moving encoding/decoding to `pipe.device` fixed vid2vid.