### PR TITLE
Fix RuntimeError: Expected all tensors to be on the same device

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -91,11 +91,11 @@ def prepare_input_latents(
         # initialize with random gaussian noise
         scale = pipe.vae_scale_factor
         shape = (batch_size, pipe.unet.config.in_channels, num_frames, height // scale, width // scale)
-        latents = torch.randn(shape, dtype=torch.half, device=pipe.device)
+        latents = torch.randn(shape, dtype=torch.half)
 
     else:
         # encode init_video to latents
-        latents = encode(pipe, init_video, vae_batch_size)
+        latents = encode(pipe, init_video, vae_batch_size).to(pipe.device)
         if latents.shape[0] != batch_size:
             latents = latents.repeat(batch_size, 1, 1, 1, 1)
 

--- a/inference.py
+++ b/inference.py
@@ -91,11 +91,11 @@ def prepare_input_latents(
         # initialize with random gaussian noise
         scale = pipe.vae_scale_factor
         shape = (batch_size, pipe.unet.config.in_channels, num_frames, height // scale, width // scale)
-        latents = torch.randn(shape, dtype=torch.half, device=pipe.device)
+        latents = torch.randn(shape, dtype=torch.half)
 
     else:
         # encode init_video to latents
-        latents = encode(pipe, init_video, vae_batch_size).to(pipe.device)
+        latents = encode(pipe, init_video, vae_batch_size)
         if latents.shape[0] != batch_size:
             latents = latents.repeat(batch_size, 1, 1, 1, 1)
 
@@ -220,7 +220,7 @@ def diffuse(
                 ]
                 pipe.scheduler.lower_order_nums = min(i, order)
 
-                latents_window = latents[:, :, idx : idx + window_size, :, :]
+                latents_window = latents[:, :, idx : idx + window_size, :, :].to(pipe.device)
 
                 # expand the latents if we are doing classifier free guidance
                 latent_model_input = torch.cat([latents_window] * 2) if do_classifier_free_guidance else latents_window

--- a/inference.py
+++ b/inference.py
@@ -91,7 +91,7 @@ def prepare_input_latents(
         # initialize with random gaussian noise
         scale = pipe.vae_scale_factor
         shape = (batch_size, pipe.unet.config.in_channels, num_frames, height // scale, width // scale)
-        latents = torch.randn(shape, dtype=torch.half)
+        latents = torch.randn(shape, dtype=torch.half, device=pipe.device)
 
     else:
         # encode init_video to latents


### PR DESCRIPTION
Encountered the following error running inference.py with an init_video
```RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument mat1 in method wrapper_addmm```

Fixed by sending the video latents to the GPU with .to(pipe.device).