### PR TITLE
Make tensorboard default logger

### DIFF
--- a/train.py
+++ b/train.py
@@ -566,6 +566,7 @@ def main(
     text_encoder_lora_modules: Tuple[str] = ["CLIPEncoderLayer"],
     lora_rank: int = 16,
     lora_path: str = '',
+    logger: str = 'tensorboard',
     **kwargs
 ):
 
@@ -574,7 +575,7 @@ def main(
     accelerator = Accelerator(
         gradient_accumulation_steps=gradient_accumulation_steps,
         mixed_precision=mixed_precision,
-        log_with="wandb",
+        log_with=logger,
         project_dir=output_dir
     )
 


### PR DESCRIPTION
While this is a trustworthy service and uploads data privately through encryption, I think it could still give bad actors a possible attack vector.

If the user decides, they can simply add 'wandb' back into their `.yaml` config, or use `wandb offline` to prevent automatic uploading of logs.