### PR TITLE
Stable LoRA addition and webui text2video extension support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [output.webm](https://user-images.githubusercontent.com/59846140/230748413-fe91e90b-94b9-49ea-97ec-250469ee9472.webm)
 
 ### Updates
+- **2023-7-12**: You can now train a LoRA that is compatibile with the [webui extension](https://github.com/kabachuha/sd-webui-text2video)! See instructions [here.](https://github.com/ExponentialML/Text-To-Video-Finetuning/edit/feat/stable_lora/README.md#training-a-lora)
 - **2023-4-17**: You can now convert your trained models from diffusers to `.ckpt` format for A111 webui. Thanks @kabachuha!  
 - **2023-4-8**: LoRA Training released! Checkout `configs/v2/lora_training_config.yaml` for instructions. 
 - **2023-4-8**: Version 2 is released! 
@@ -46,14 +47,12 @@ It is **highly recommended** to install >= Torch 2.0. This way, you don't have t
 
 If you don't have Xformers enabled, you can follow the instructions here: https://github.com/facebookresearch/xformers
 
-
 Recommended to use a RTX 3090, but you should be able to train on GPUs with <= 16GB ram with:
 - Validation turned off.
 - Xformers or Torch 2.0 Scaled Dot-Product Attention 
 - Gradient checkpointing enabled. 
 - Resolution of 256.
 - Enable all LoRA options.
-
 
 ## Running inference
 The `inference.py` script can be used to render videos with trained checkpoints.
@@ -163,6 +162,18 @@ I highly recommend (I did this myself) going to `configs/v2/train_config.yaml`. 
 Then, follow each line and configure it for your specific use case. 
 
 The instructions should be clear enough to get you up and running with your dataset, but feel free to ask any questions in the discussion board.
+
+## Training a LoRA
+You can also train a LoRA that is both compatible with the webui extension.. By default it's set to 'cloneofsimo', which was the first LoRA implementation for Stable Diffusion.
+This version you can use in the `inference.py` file in this repository. It is **not** compatible with the webui.
+
+To use a LoRA with the webui, change the `lora_version` to "stable_lora" in your config. This will train an [A1111 webui extension](https://github.com/kabachuha/sd-webui-text2video) compatibile LoRA.
+You can get started at `configs/v2/stable_lora_config.yaml` and edit it from there. During and after training, LoRAs will be saved in your outputs directory with the prefix `_webui`.
+
+### What you cannot do:
+- Use LoRA files that were made for SD image models in other trainers.
+- Use 'cloneofsimo' LoRAs in another project (unless you build it or create a PR)
+- Merge LoRA weights together (yet).
 
 ## Finetune.
 ```python

--- a/configs/v2/stable_lora_config.yaml
+++ b/configs/v2/stable_lora_config.yaml
@@ -39,9 +39,6 @@ cache_latents: True
 # you can skip the caching process and load previously saved ones. 
 cached_latent_dir: null #/path/to/cached_latents
 
-# Train the text encoder for the model. LoRA Training overrides this setting.
-train_text_encoder: False
-
 # https://github.com/cloneofsimo/lora (NOT Compatible with webui extension)
 # This is the first, original implementation of LoRA by cloneofsimo.
 # Use this version if you want to maintain compatibility to the original version.
@@ -80,11 +77,11 @@ only_lora_for_webui: False
 
 # Choose whether or not ito save the full pretrained model weights for both checkpoints and after training.
 # The only time you want this off is if you're doing full LoRA training.
-save_pretrained_model: True
+save_pretrained_model: False
 
-# The modules to use for LoRA. Different from 'trainable_modules'.
+# The modules to use for LoRA. Advanced usage.
 unet_lora_modules:
-  - "UNet3DConditionModel"
+  - "UNet3DConditionModel" # Defaults to training the entire UNET.
   #- "ResnetBlock2D"
   #- "TransformerTemporalModel"
   #- "Transformer2DModel"
@@ -93,9 +90,8 @@ unet_lora_modules:
   #- "GEGLU"
   #- "TemporalConvLayer"
 
-# The modules to use for LoRA. Different from `trainable_text_modules`.
 text_encoder_lora_modules:
-  - "CLIPEncoderLayer"
+  - "CLIPEncoderLayer" # Defaults to training the entire Text Encoder.
   #- "CLIPAttention"
 
 # The rank for LoRA training. With ModelScope, the maximum should be 1024. 
@@ -169,7 +165,7 @@ validation_data:
   guidance_scale: 9
 
 # Learning rate for AdamW
-learning_rate: 5e-6
+learning_rate: 2e-5
 
 # Weight decay. Higher = more regularization. Lower = closer to dataset.
 adam_weight_decay: 0
@@ -196,24 +192,6 @@ checkpointing_steps: 2500
 # How many steps to do for validation if sample_preview is enabled.
 validation_steps: 100
 
-# Which modules we want to unfreeze for the UNET. Advanced usage.
-trainable_modules:
-  - "all"
-  # If you want to ignore temporal attention entirely, remove "attn1-2" and replace with ".attentions"
-  # This is for self attetion. Activates for spatial and temporal dimensions if n_sample_frames > 1
-  #- "attn1"
-  
-  # This is for cross attention (image & text data). Activates for spatial and temporal dimensions if n_sample_frames > 1
-  #- "attn2"
-  
-  #  Convolution networks that hold temporal information. Activates for spatial and temporal dimensions if n_sample_frames > 1
-  #- 'temp_conv'
-
-
-# Which modules we want to unfreeze for the Text Encoder. Advanced usage.
-trainable_text_modules:
-  - "all"
-
 # Seed for validation.
 seed: 64
 
@@ -226,7 +204,6 @@ use_8bit_adam: False
 # Trades VRAM usage for speed. You lose roughly 20% of training speed, but save a lot of VRAM.
 # If you need to save more VRAM, it can also be enabled for the text encoder, but reduces speed x2.
 gradient_checkpointing: True
-text_encoder_gradient_checkpointing: False
 
 # Xformers must be installed for best memory savings and performance (< Pytorch 2.0)
 enable_xformers_memory_efficient_attention: False

--- a/configs/v2/train_config.yaml
+++ b/configs/v2/train_config.yaml
@@ -72,9 +72,11 @@ save_lora_for_webui: True
 # when this version is set to False
 only_lora_for_webui: False
 
+# Choose whether or not ito save the full pretrained model weights for both checkpoints and after training.
+# The only time you want this off is if you're doing full LoRA training.
+save_pretrained_model: True
+
 # The modules to use for LoRA. Different from 'trainable_modules'.
-
-
 unet_lora_modules:
   - "UNet3DConditionModel"
   #- "ResnetBlock2D"

--- a/configs/v2/train_config.yaml
+++ b/configs/v2/train_config.yaml
@@ -37,16 +37,34 @@ cached_latent_dir: null #/path/to/cached_latents
 # Train the text encoder. Leave at false to use LoRA only (Recommended).
 train_text_encoder: False
 
-# https://github.com/cloneofsimo/lora
-# Use LoRA to train extra layers whilst saving memory. It trains both a LoRA & the model itself.
-# This works slightly different than vanilla LoRA and DOES NOT save a separate file.
-# It is simply used as a mechanism for saving memory by keeping layers frozen and training the residual.
+# https://github.com/cloneofsimo/lora (NOT Compatible with webui extension)
+# This is the first, original implementation of LoRA by cloneofsimo.
+# Use this version if you want to maintain compatibility to the original version.
 
+# https://github.com/ExponentialML/Stable-LoRA/tree/main (Compatible with webui text2video extension)
+# This is an implementation based off of the original LoRA repository by Microsoft, and the default LoRA method here.
+# It works a different by using embeddings instead of the intermediate activations (Linear || Conv).
+# This means that there isn't an extra function when doing low ranking adaption.
+# It solely saves the weight differential between the initialized weights and updates. 
+
+# "cloneofsimo" or "stable_lora"
+lora_version: "stable_lora"
 # Use LoRA for the UNET model.
 use_unet_lora: True
 
 # Use LoRA for the Text Encoder.
 use_text_lora: True
+
+# https://github.com/kabachuha/sd-webui-text2video
+# This saves a LoRA that is compatible with the text2video webui extension.
+# It only works when the lora version is 'stable_lora'.
+# This is also a DIFFERENT implementation than Kohya's, so it will NOT work the same implementation.
+save_lora_for_webui: True
+
+# The LoRA file will be converted to a different format to be compatible with the webui extension.
+# The difference between this and 'save_lora_for_webui' is that you can continue training a Diffusers pipeline model
+# when this version is set to False
+only_lora_for_webui: False
 
 # The modules to use for LoRA. Different from 'trainable_modules'.
 unet_lora_modules:

--- a/configs/v2/train_config.yaml
+++ b/configs/v2/train_config.yaml
@@ -53,7 +53,7 @@ train_text_encoder: False
 # It solely saves the weight differential between the initialized weights and updates. 
 
 # "cloneofsimo" or "stable_lora"
-lora_version: "stable_lora"
+lora_version: "cloneofsimo"
 
 # Use LoRA for the UNET model.
 use_unet_lora: True

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ torchvision
 torchaudio
 git+https://github.com/huggingface/diffusers.git
 git+https://github.com/cloneofsimo/lora.git
+git+https://github.com/microsoft/LoRA
 transformers
 einops
 decord

--- a/stable_lora/lora.py
+++ b/stable_lora/lora.py
@@ -189,7 +189,6 @@ class Conv3d(nn.Conv3d, LoRALayer):
             )
         return nn.Conv3d.forward(self, x)
 
-
 def create_lora_linear(child_module, r, dropout=0, bias=False, scale=0):
     return loralb.Linear(
         child_module.in_features, 
@@ -208,6 +207,7 @@ def create_lora_conv(child_module, r, dropout=0, bias=False, rescale=False, scal
         child_module.out_channels,
         kernel_size=child_module.kernel_size[0],
         padding=child_module.padding,
+        stride=child_module.stride,
         merge_weights=False,
         bias=bias,
         lora_dropout=dropout,

--- a/stable_lora/lora.py
+++ b/stable_lora/lora.py
@@ -326,8 +326,10 @@ def save_lora(
         if not only_webui:
             for i, model in enumerate([unet, text_encoder]):
                 if save_text_weights and i == 1:
-                    save_path_full_weights = save_path_full_weights.replace(ext, f"_text{ext}")
-                    
+                    save_path_full_weights = save_path_full_weights.replace(ext, f"_text_encoder{ext}")
+
+                else:
+                    save_path_full_weights = save_path_full_weights.replace(ext, f"_unet{ext}")
                 # Load only the LoRAs from the state dict.
                 lora_dict = loralb.lora_state_dict(model, bias=lora_bias)
                 

--- a/stable_lora/lora.py
+++ b/stable_lora/lora.py
@@ -316,7 +316,7 @@ def save_lora(
 
         ext = '.safetensors'
         # Create LoRA out filename.
-        lora_out_file = f"{output_dir}/{lora_filename}{ext}"
+        lora_out_file = f"{output_dir}/webui_{lora_filename}{ext}"
 
         if not only_webui:
             save_path_full_weights = lora_out_file_full_weight + ext

--- a/stable_lora/lora.py
+++ b/stable_lora/lora.py
@@ -319,22 +319,23 @@ def save_lora(
         lora_out_file = f"{output_dir}/{lora_filename}{ext}"
 
         if not only_webui:
-            save_path_full_weights = lora_out_file_full_weight
+            save_path_full_weights = lora_out_file_full_weight + ext
 
         save_path = lora_out_file
 
         if not only_webui:
             for i, model in enumerate([unet, text_encoder]):
                 if save_text_weights and i == 1:
-                    save_path_full_weights = save_path_full_weights.replace(ext, f"_text_encoder{ext}")
+                    non_webui_weights = save_path_full_weights.replace(ext, f"_text_encoder{ext}")
 
                 else:
-                    save_path_full_weights = save_path_full_weights.replace(ext, f"_unet{ext}")
+                    non_webui_weights = save_path_full_weights.replace(ext, f"_unet{ext}")
+
                 # Load only the LoRAs from the state dict.
                 lora_dict = loralb.lora_state_dict(model, bias=lora_bias)
                 
                 # Save the models as fp32. This ensures we can finetune again without having to upcast.                      
-                save_file(lora_dict, save_path_full_weights)
+                save_file(lora_dict, non_webui_weights)
         
         if save_for_webui:
             # Convert the keys to compvis model and webui

--- a/stable_lora/lora.py
+++ b/stable_lora/lora.py
@@ -11,7 +11,7 @@ from torch.utils.data import ConcatDataset
 from transformers import CLIPTokenizer
 
 try:
-    from safetensors.torch import save_file, safe_open
+    from safetensors.torch import save_file, load_file
 except: 
     print("Safetensors is not installed. Saving while using use_safetensors will fail.")
 
@@ -359,7 +359,7 @@ def save_lora(
 def load_lora(model, lora_path: str):
     try:
         if os.path.exists(lora_path):
-            lora_dict = safe_open(lora_path, framework='pt')
+            lora_dict = load_file(lora_path)
             model.load_state_dict(lora_dict, strict=False)
 
     except Exception as e:

--- a/stable_lora/lora.py
+++ b/stable_lora/lora.py
@@ -184,10 +184,11 @@ class Conv3d(nn.Conv3d, LoRALayer):
         if self.r > 0 and not self.merged:
             return F.conv3d(
                 x, 
-                self.weight + (self.lora_B.transpose(0,1) @ self.lora_A.transpose(0,1)).view(self.weight.shape) * self.scaling,
-                self.bias, self.stride, self.padding, self.dilation, self.groups
+                self.weight + torch.mean((self.lora_B @ self.lora_A).view(self.view_shape), dim=-2,  keepdim=True) * \
+                    self.scaling, self.bias, self.stride, self.padding, self.dilation, self.groups
             )
-        return nn.Conv2d.forward(self, x)
+        return nn.Conv3d.forward(self, x)
+
 
 def create_lora_linear(child_module, r, dropout=0, bias=False, scale=0):
     return loralb.Linear(

--- a/stable_lora/lora.py
+++ b/stable_lora/lora.py
@@ -1,0 +1,309 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import os
+import loralib as loralb
+from loralib import LoRALayer
+import math
+import json
+
+from torch.utils.data import ConcatDataset
+from transformers import CLIPTokenizer
+
+try:
+    from safetensors.torch import save_file, safe_open
+except: 
+    print("Safetensors is not installed. Saving while using use_safetensors will fail.")
+
+UNET_REPLACE = ["Transformer2DModel", "ResnetBlock2D"]
+TEXT_ENCODER_REPLACE = ["CLIPAttention", "CLIPTextEmbeddings"]
+
+UNET_ATTENTION_REPLACE = ["CrossAttention"]
+TEXT_ENCODER_ATTENTION_REPLACE = ["CLIPAttention", "CLIPTextEmbeddings"]
+
+"""
+Copied from: https://github.com/cloneofsimo/lora/blob/bdd51b04c49fa90a88919a19850ec3b4cf3c5ecd/lora_diffusion/lora.py#L189
+"""
+def find_modules(
+        model,
+        ancestor_class= None,
+        search_class = [torch.nn.Linear],
+        exclude_children_of = [loralb.Linear, loralb.Conv2d, loralb.Embedding],
+    ):
+        """
+        Find all modules of a certain class (or union of classes) that are direct or
+        indirect descendants of other modules of a certain class (or union of classes).
+
+        Returns all matching modules, along with the parent of those moduless and the
+        names they are referenced by.
+        """
+
+        # Get the targets we should replace all linears under
+        if ancestor_class is not None:
+            ancestors = (
+                module
+                for module in model.modules()
+                if module.__class__.__name__ in ancestor_class
+            )
+        else:
+            # this, incase you want to naively iterate over all modules.
+            ancestors = [module for module in model.modules()]
+
+        # For each target find every linear_class module that isn't a child of a LoraInjectedLinear
+        for ancestor in ancestors:
+            for fullname, module in ancestor.named_modules():
+                if any([isinstance(module, _class) for _class in search_class]):
+                    # Find the direct parent if this is a descendant, not a child, of target
+                    *path, name = fullname.split(".")
+                    parent = ancestor
+                    while path:
+                        parent = parent.get_submodule(path.pop(0))
+                    # Skip this linear if it's a child of a LoraInjectedLinear
+                    if exclude_children_of and any(
+                        [isinstance(parent, _class) for _class in exclude_children_of]
+                    ):
+                        continue
+                    # Otherwise, yield it
+                    yield parent, name, module
+
+class Conv3d(nn.Conv3d, LoRALayer):
+    # LoRA implemented in a dense layer
+    def __init__(
+        self, 
+        in_channels: int, 
+        out_channels: int,
+        kernel_size: int,
+        r: int = 0, 
+        lora_alpha: int = 1, 
+        lora_dropout: float = 0.,
+        merge_weights: bool = True,
+        **kwargs
+    ):
+        nn.Conv3d.__init__(self, in_channels, out_channels, (kernel_size, 1, 1), **kwargs)
+        LoRALayer.__init__(self, r=r, lora_alpha=lora_alpha, lora_dropout=lora_dropout,
+                           merge_weights=merge_weights)
+        assert type(kernel_size) is int
+        # Actual trainable parameters
+        if r > 0:
+            self.lora_A = nn.Parameter(
+                self.weight.new_zeros((r*kernel_size, in_channels*kernel_size, kernel_size))
+            )
+            self.lora_B = nn.Parameter(
+                self.weight.new_zeros((kernel_size, out_channels*kernel_size, r*kernel_size))
+            )
+            self.scaling = self.lora_alpha / self.r
+            # Freezing the pre-trained weight matrix
+            self.weight.requires_grad = False
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        nn.Conv3d.reset_parameters(self)
+        if hasattr(self, 'lora_A'):
+            # initialize A the same way as the default for nn.Linear and B to zero
+            nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
+            nn.init.zeros_(self.lora_B)
+
+    def train(self, mode: bool = True):
+        nn.Conv3d.train(self, mode)
+        if mode:
+            if self.merge_weights and self.merged:
+                # Make sure that the weights are not merged
+                self.weight.data -= (self.lora_B @ self.lora_A).view(self.weight.shape) * self.scaling
+                self.merged = False
+        else:
+            if self.merge_weights and not self.merged:
+                # Merge the weights and mark it
+                self.weight.data += (self.lora_B @ self.lora_A).view(self.weight.shape) * self.scaling
+                self.merged = True
+
+    def forward(self, x: torch.Tensor):
+        if self.r > 0 and not self.merged:
+            return F.conv3d(
+                x, 
+                self.weight + (self.lora_B.transpose(0,1) @ self.lora_A.transpose(0,1)).view(self.weight.shape) * self.scaling,
+                self.bias, self.stride, self.padding, self.dilation, self.groups
+            )
+        return nn.Conv2d.forward(self, x)
+
+def create_lora_linear(child_module, r, dropout=0, bias=False, scale=0):
+    return loralb.Linear(
+        child_module.in_features, 
+        child_module.out_features, 
+        merge_weights=False,
+        bias=bias,
+        lora_dropout=dropout,
+        lora_alpha=r,
+        r=r
+    )
+    return lora_linear
+
+def create_lora_conv(child_module, r, dropout=0, bias=False, rescale=False, scale=0):
+    return loralb.Conv2d(
+        child_module.in_channels, 
+        child_module.out_channels,
+        kernel_size=child_module.kernel_size[0],
+        padding=child_module.padding,
+        merge_weights=False,
+        bias=bias,
+        lora_dropout=dropout,
+        lora_alpha=r,
+        r=r,
+    )
+    return lora_conv    
+
+def create_lora_conv3d(child_module, r, dropout=0, bias=False, rescale=False, scale=0):
+    return Conv3d(
+        child_module.in_channels, 
+        child_module.out_channels,
+        kernel_size=child_module.kernel_size[0],
+        padding=child_module.padding,
+        stride=child_module.stride,
+        merge_weights=False,
+        bias=bias,
+        lora_dropout=dropout,
+        lora_alpha=r,
+        r=r,
+    )
+    return lora_conv  
+
+def create_lora_emb(child_module, r):
+    return loralb.Embedding(
+        child_module.num_embeddings, 
+        child_module.embedding_dim, 
+        merge_weights=False,
+        lora_alpha=r,
+        r=r
+    )
+
+def activate_lora_train(model, bias):
+    def unfreeze():
+        print(model.__class__.__name__ + " LoRA set for training.")
+        return loralb.mark_only_lora_as_trainable(model, bias=bias)
+
+    return unfreeze
+
+def add_lora_to(
+    model, 
+    target_module=UNET_REPLACE, 
+    search_class=[torch.nn.Linear], 
+    r=32, 
+    dropout=0,
+    lora_bias='none'
+):
+    for module, name, child_module in find_modules(
+        model, 
+        ancestor_class=target_module, 
+        search_class=search_class
+    ):
+        bias = hasattr(child_module, "bias")
+
+        # Check if the child module of the model is type Linear or Conv2d.
+        if isinstance(child_module, torch.nn.Linear):
+            l = create_lora_linear(child_module, r, dropout, bias=bias)
+
+        if isinstance(child_module, torch.nn.Conv2d):
+            l = create_lora_conv(child_module, r, dropout, bias=bias)
+
+        if isinstance(child_module, torch.nn.Conv3d):
+            l = create_lora_conv3d(child_module, r, dropout, bias=bias)
+
+        if isinstance(child_module, torch.nn.Embedding):
+            l = create_lora_emb(child_module, r)
+            
+        # Check if child module of the model has bias.
+        if bias:
+            l.bias = child_module.bias
+        
+        # Assign the frozen weight of model's Linear or Conv2d to the LoRA model.
+        l.weight =  child_module.weight
+
+        # Replace the new LoRA model with the model's Linear or Conv2d module.
+        module._modules[name] = l
+        
+
+    # Unfreeze only the newly added LoRA weights, but keep the model frozen.
+    return activate_lora_train(model, lora_bias)
+
+def save_lora(
+        unet=None, 
+        text_encoder=None, 
+        save_text_weights=False,
+        output_dir="output",
+        lora_filename="lora.safetensors",
+        lora_bias='none', 
+        save_for_webui=True,
+        only_webui=False,
+        metadata=None,
+        unet_dict_converter=None,
+        text_dict_converter=None
+    ):
+
+        if not only_webui:
+            # Create directory for the full LoRA weights.
+            trainable_weights_dir = f"{output_dir}/full_weights"
+            lora_out_file_full_weight = f"{trainable_weights_dir}/{lora_filename}"
+            os.makedirs(trainable_weights_dir, exist_ok=True)
+
+        ext = '.safetensors'
+        # Create LoRA out filename.
+        lora_out_file = f"{output_dir}/{lora_filename}{ext}"
+
+        if not only_webui:
+            save_path_full_weights = lora_out_file_full_weight
+
+        save_path = lora_out_file
+
+        if not only_webui:
+            for i, model in enumerate([unet, text_encoder]):
+                if save_text_weights and i == 1:
+                    save_path_full_weights = save_path_full_weights.replace(ext, f"_text{ext}")
+                    
+                # Load only the LoRAs from the state dict.
+                lora_dict = loralb.lora_state_dict(model, bias=lora_bias)
+                
+                # Save the models as fp32. This ensures we can finetune again without having to upcast.                      
+                save_file(lora_dict, save_path_full_weights)
+        
+        if save_for_webui:
+            # Convert the keys to compvis model and webui
+            unet_lora_dict = loralb.lora_state_dict(unet, bias=lora_bias) 
+            lora_dict_fp16 = unet_dict_converter(unet_lora_dict, strict_mapping=True)
+            
+            if save_text_weights:
+                text_encoder_dict = loralb.lora_state_dict(text_encoder, bias=lora_bias)
+                lora_dict_text_fp16 = text_dict_converter(text_encoder_dict)
+                
+                # Update the Unet dict to include text keys.
+                lora_dict_fp16.update(lora_dict_text_fp16)
+
+            # Cast tensors to fp16. It's assumed we won't be finetuning these.
+            for k, v in lora_dict_fp16.items():
+                lora_dict_fp16[k] = v.to(dtype=torch.float16)
+
+            save_file(
+                lora_dict_fp16, 
+                save_path, 
+                metadata=metadata
+            )
+
+def load_lora(model, lora_path: str):
+    try:
+        if os.path.exists(lora_path):
+            lora_dict = safe_open(lora_path, framework='pt')
+            model.load_state_dict(lora_dict, strict=False)
+
+    except Exception as e:
+        print(f"Could not load your lora file: {e}")
+
+def set_mode(model, train=False):
+    for n, m in model.named_modules():
+        is_lora = any(
+            isinstance(m,x) for x in [loralb.Linear, loralb.Conv2d, Conv3d, loralb.Embedding]
+        )
+        if is_lora:
+            m.train(train)
+
+def set_mode_group(models, train):
+   for model in models: 
+        set_mode(model)
+        model.train(train)

--- a/train.py
+++ b/train.py
@@ -866,7 +866,8 @@ def main(
                         lora_manager,
                         unet_lora_modules,
                         text_encoder_lora_modules,
-                        is_checkpoint=True
+                        is_checkpoint=True,
+                        save_pretrained_model=save_pretrained_model
                     )
 
                 if should_sample(global_step, validation_steps, validation_data):
@@ -942,7 +943,8 @@ def main(
                 lora_manager,
                 unet_lora_modules,
                 text_encoder_lora_modules,
-                is_checkpoint=False
+                is_checkpoint=False,
+                save_pretrained_model=save_pretrained_model
         )     
     accelerator.end_training()
 

--- a/train.py
+++ b/train.py
@@ -401,6 +401,7 @@ def save_pipe(
         unet_target_replace_module=None,
         text_target_replace_module=None,
         is_checkpoint=False,
+        save_pretrained_model=True
     ):
 
     if is_checkpoint:
@@ -424,6 +425,9 @@ def save_pipe(
     ).to(torch_dtype=torch.float32)
     
     lora_manager.save_lora_weights(model=pipeline, save_path=save_path, step=global_step)
+
+    if save_pretrained_model:
+        pipeline.save_pretrained(save_path)
 
     pipeline.save_pretrained(save_path)
     
@@ -494,6 +498,7 @@ def main(
     use_text_lora: bool = False,
     unet_lora_modules: Tuple[str] = ["ResnetBlock2D"],
     text_encoder_lora_modules: Tuple[str] = ["CLIPEncoderLayer"],
+    save_pretrained_model: bool = True,
     lora_rank: int = 16,
     lora_path: str = '',
     logger: str = 'tensorboard',

--- a/train.py
+++ b/train.py
@@ -499,6 +499,8 @@ def main(
     save_pretrained_model: bool = True,
     lora_rank: int = 16,
     lora_path: str = '',
+    lora_unet_dropout: float = 0.1,
+    lora_text_dropout: float = 0.1,
     logger: str = 'tensorboard',
     **kwargs
 ):
@@ -544,7 +546,6 @@ def main(
     optimizer_cls = get_optimizer(use_8bit_adam)
 
     # Use LoRA if enabled.  
-    dropout = 0
     lora_manager = LoraHandler(
         version=lora_version, 
         use_unet_lora=use_unet_lora,
@@ -557,10 +558,10 @@ def main(
     )
 
     unet_lora_params, unet_negation = lora_manager.add_lora_to_model(
-        use_unet_lora, unet, lora_manager.unet_replace_modules, dropout, lora_path, r=lora_rank) 
+        use_unet_lora, unet, lora_manager.unet_replace_modules, lora_unet_dropout, lora_path, r=lora_rank) 
 
     text_encoder_lora_params, text_encoder_negation = lora_manager.add_lora_to_model(
-        use_text_lora, text_encoder, lora_manager.text_encoder_replace_modules, dropout, lora_path, r=lora_rank) 
+        use_text_lora, text_encoder, lora_manager.text_encoder_replace_modules, lora_text_dropout, lora_path, r=lora_rank) 
 
     # Create parameters to optimize over with a condition (if "condition" is true, optimize it)
     optim_params = [
@@ -575,7 +576,7 @@ def main(
                         extra_params={**{"lr": learning_rate}, **extra_text_encoder_params}
                     )
     ]
-    
+
     params = create_optimizer_params(optim_params, learning_rate)
     
     # Create Optimizer

--- a/train.py
+++ b/train.py
@@ -170,6 +170,7 @@ def handle_memory_attention(enable_xformers_memory_efficient_attention, enable_t
         print("Could not enable memory efficient attention for xformers or Torch 2.0.")
 
 def param_optim(model, condition, extra_params=None, is_lora=False, negation=None):
+    extra_params = extra_params if len(extra_params.keys()) > 1 else None
     return {
         "model": model, 
         "condition": condition, 
@@ -564,6 +565,9 @@ def main(
         use_text_lora, text_encoder, lora_manager.text_encoder_replace_modules, lora_text_dropout, lora_path, r=lora_rank) 
 
     # Create parameters to optimize over with a condition (if "condition" is true, optimize it)
+    extra_unet_params = extra_unet_params if extra_unet_params is not None else {}
+    extra_text_encoder_params = extra_unet_params if extra_unet_params is not None else {}
+
     optim_params = [
         param_optim(unet, trainable_modules is not None, extra_params=extra_unet_params, negation=unet_negation),
         param_optim(text_encoder, train_text_encoder and not use_text_lora, extra_params=extra_text_encoder_params, 

--- a/train.py
+++ b/train.py
@@ -170,7 +170,7 @@ def handle_memory_attention(enable_xformers_memory_efficient_attention, enable_t
         print("Could not enable memory efficient attention for xformers or Torch 2.0.")
 
 def param_optim(model, condition, extra_params=None, is_lora=False, negation=None):
-    extra_params = extra_params if len(extra_params.keys()) > 1 else None
+    extra_params = extra_params if len(extra_params.keys()) > 0 else None
     return {
         "model": model, 
         "condition": condition, 

--- a/utils/convert_diffusers_to_original_ms_text_to_video.py
+++ b/utils/convert_diffusers_to_original_ms_text_to_video.py
@@ -169,7 +169,7 @@ for j in range(2):
     unet_conversion_map_layer.append((sd_mid_res_prefix, hf_mid_res_prefix))
 
 # The pipeline
-def convert_unet_state_dict(unet_state_dict):
+def convert_unet_state_dict(unet_state_dict, strict_mapping=False):
     print ('Converting the UNET')
     # buyer beware: this is a *brittle* function,
     # and correct output requires that all of these pieces interact in
@@ -177,7 +177,11 @@ def convert_unet_state_dict(unet_state_dict):
     mapping = {k: k for k in unet_state_dict.keys()}
 
     for sd_name, hf_name in unet_conversion_map:
-        mapping[hf_name] = sd_name
+        if strict_mapping:
+            if hf_name in mapping:
+                mapping[hf_name] = sd_name
+        else:
+            mapping[hf_name] = sd_name
     for k, v in mapping.items():
         if "resnets" in k:
             for sd_part, hf_part in unet_conversion_map_resnet:

--- a/utils/lora_handler.py
+++ b/utils/lora_handler.py
@@ -53,8 +53,8 @@ lora_args = dict(
 LoraVersions = SimpleNamespace(**lora_versions)
 LoraFuncTypes = SimpleNamespace(**lora_func_types)
 
-LORA_VERSIONS = Literal[LoraVersions.stable_lora, LoraVersions.cloneofsimo]
-LORA_FUNC_TYPES = Literal[LoraFuncTypes.loader, LoraFuncTypes.injector]
+LORA_VERSIONS = [LoraVersions.stable_lora, LoraVersions.cloneofsimo]
+LORA_FUNC_TYPES = [LoraFuncTypes.loader, LoraFuncTypes.injector]
 
 def filter_dict(_dict, keys=[]):
     if len(keys) == 0:

--- a/utils/lora_handler.py
+++ b/utils/lora_handler.py
@@ -290,14 +290,14 @@ class LoraHandler(object):
     ):
         import uuid
 
-        save_filename = f"{step}_{name}"
+        save_filename = f"{step}_{name}{LORA_FILE_TYPES[-1]}"
         lora_metadata =  metadata = {
         "stable_lora_text_to_video": "v1", 
         "lora_name": name + "_" + uuid.uuid4().hex.lower()[:5]
     }
         save_lora(
-            model.unet,
-            model.text_encoder,
+            unet=model.unet,
+            text_encoder=model.text_encoder,
             save_text_weights=self.use_text_lora,
             output_dir=save_path,
             lora_filename=save_filename,

--- a/utils/lora_handler.py
+++ b/utils/lora_handler.py
@@ -313,7 +313,7 @@ class LoraHandler(object):
     ):
         import uuid
 
-        save_filename = f"{step}_{name}.{LORA_FILE_TYPES[-1]}"
+        save_filename = f"{step}_{name}"
         lora_metadata =  metadata = {
         "stable_lora_text_to_video": "v1", 
         "lora_name": name + "_" + uuid.uuid4().hex.lower()[:5]

--- a/utils/lora_handler.py
+++ b/utils/lora_handler.py
@@ -1,7 +1,7 @@
 import os
 from logging import warnings
 import torch
-from typing import Literal, Union
+from typing import Union
 from types import SimpleNamespace
 from models.unet_3d_condition import UNet3DConditionModel
 from transformers import CLIPTextModel

--- a/utils/lora_handler.py
+++ b/utils/lora_handler.py
@@ -1,0 +1,328 @@
+import os
+from logging import warnings
+import torch
+from typing import Literal, Union
+from types import SimpleNamespace
+from models.unet_3d_condition import UNet3DConditionModel
+from transformers import CLIPTextModel
+from utils.convert_diffusers_to_original_ms_text_to_video import convert_unet_state_dict, convert_text_enc_state_dict_v20
+
+from .lora import (
+    extract_lora_ups_down,
+    inject_trainable_lora_extended,
+    save_lora_weight,
+    train_patch_pipe,
+    monkeypatch_or_replace_lora,
+    monkeypatch_or_replace_lora_extended
+)
+
+from stable_lora.lora import (
+    activate_lora_train,
+    add_lora_to,
+    save_lora,
+    load_lora,
+    set_mode_group
+)
+
+FILE_BASENAMES = ['unet', 'text_encoder']
+LORA_FILE_TYPES = ['.pt', '.safetensors']
+CLONE_OF_SIMO_KEYS = ['model', 'loras', 'target_replace_module', 'r']
+STABLE_LORA_KEYS = ['model', 'target_module', 'search_class', 'r', 'dropout', 'lora_bias']
+
+lora_versions = dict(
+    stable_lora = "stable_lora",
+    cloneofsimo = "cloneofsimo"
+)
+
+lora_func_types = dict(
+    loader = "loader",
+    injector = "injector"
+)
+
+lora_args = dict(
+    model = None,
+    loras = None,
+    target_replace_module = [],
+    target_module = [],
+    r = 4,
+    search_class = [torch.nn.Linear],
+    dropout = 0,
+    lora_bias = 'none'
+)
+
+LoraVersions = SimpleNamespace(**lora_versions)
+LoraFuncTypes = SimpleNamespace(**lora_func_types)
+
+LORA_VERSIONS = Literal[LoraVersions.stable_lora, LoraVersions.cloneofsimo]
+LORA_FUNC_TYPES = Literal[LoraFuncTypes.loader, LoraFuncTypes.injector]
+
+def is_valid_lora_file( 
+        file_basename, 
+        file_name, 
+        train_model, 
+        model_type: Union[CLIPTextModel, UNet3DConditionModel] = None
+    ):
+        return file_basename in file_name and isinstance(train_model, model_type)
+
+def filter_dict(_dict, keys=[]):
+    if len(keys) == 0:
+        assert "Keys cannot empty for filtering return dict."
+    
+    for k in keys:
+        if k not in lora_args.keys():
+            assert f"{k} does not exist in available LoRA arguments"
+            
+    return {k: v for k, v in _dict.items() if k in keys}
+
+
+class LoraHandler(object):
+    def __init__(
+        self, 
+        version: LORA_VERSIONS = LoraVersions.cloneofsimo, 
+        use_unet_lora: bool = False,
+        use_text_lora: bool = False,
+        save_for_webui: bool = False,
+        only_for_webui: bool = False,
+        lora_bias: str = 'none',
+        unet_replace_modules: list = ['UNet3DConditionModel'],
+        text_encoder_replace_modules: list = ['CLIPEncoderLayer']
+    ):
+        self.version = version
+        self.lora_loader = self.get_lora_func(func_type=LoraFuncTypes.loader)
+        self.lora_injector = self.get_lora_func(func_type=LoraFuncTypes.injector)
+        self.lora_bias = lora_bias
+        self.use_unet_lora = use_unet_lora
+        self.use_text_lora = use_text_lora
+        self.save_for_webui = save_for_webui
+        self.only_for_webui = only_for_webui
+        self.unet_replace_modules = unet_replace_modules
+        self.text_encoder_replace_modules = text_encoder_replace_modules
+        self.use_lora = any([use_text_lora, use_unet_lora])
+
+        if self.use_lora:
+            print(f"Using LoRA Version: {self.version}")
+
+    def is_cloneofsimo_lora(self):
+        return self.version == LoraVersions.cloneofsimo
+
+    def is_stable_lora(self):
+        return self.version == LoraVersions.stable_lora
+
+    def get_lora_func(self, func_type: LORA_FUNC_TYPES = LoraFuncTypes.loader):
+
+        if self.is_cloneofsimo_lora():
+
+            if func_type == LoraFuncTypes.loader:
+                return monkeypatch_or_replace_lora_extended
+
+            if func_type == LoraFuncTypes.injector:
+                return inject_trainable_lora_extended
+
+        if self.is_stable_lora():
+
+            if func_type == LoraFuncTypes.loader:
+                return load_lora
+
+            if func_type == LoraFuncTypes.injector:
+                return add_lora_to
+                
+        assert "LoRA Version does not exist."
+
+    def handle_lora_load(
+        self, 
+        file_name, 
+        train_model: Union[CLIPTextModel, UNet3DConditionModel] = None,
+        lora_loader_args: dict = None
+    ):
+        lora_activators = []
+
+        for basename in FILE_BASENAMES:
+            if is_valid_lora_file(basename, file_name, train_model, model_type):
+                self.lora_loader(**lora_loader_args)
+                print(f"Successfully loaded LoRA for {basename}")
+
+    def load_lora(
+        self, 
+        model: Union[CLIPTextModel, UNet3DConditionModel], 
+        lora_path: str = '',
+        lora_loader_args: dict = None,
+    ):
+        try:
+            if os.path.exists(lora_path):
+                for lora_file in os.listdir(lora_path):
+                    if lora_file.endswith(LORA_FILE_TYPES):
+                        lora_file = os.path.join(lora_path, lora_file)
+                        return self.handle_lora_load(file_name, model, lora_loader_args)
+
+        except Exception as e:
+            print(e)
+            print("Could not load LoRAs. Injecting new ones instead...")
+            
+    def get_lora_func_args(self, lora_path, use_lora, model, replace_modules, r, dropout, lora_bias):
+        return_dict = lora_args.copy()
+
+        if self.is_cloneofsimo_lora():
+            return_dict = filter_dict(return_dict, keys=CLONE_OF_SIMO_KEYS)
+            return_dict.update({
+                "model": model,
+                "loras": torch.load(lora_path),
+                "target_replace_module": replace_modules,
+                "r": r
+            })
+
+        if self.is_stable_lora():
+            KEYS = ['model', 'lora_path']
+            return_dict = filter_dict(return_dict, KEYS)
+            
+            return_dict.update({'model': model, 'lora_path': lora_path})
+
+        return return_dict
+
+    def do_lora_injection(
+        self, 
+        model, 
+        replace_modules, bias='none',
+        dropout=0,
+        r=4,
+        lora_loader_args=None,
+    ):
+        params = None
+        negation = None
+        REPLACE_MODULES = replace_modules
+
+        if self.is_cloneofsimo_lora():
+            
+            injector_args = lora_loader_args
+
+            params, negation = self.lora_injector(**injector_args)   
+            for _up, _down in extract_lora_ups_down(
+                model, 
+                target_replace_module=REPLACE_MODULES):
+
+                if all(x is not None for x in [_up, _down]):
+                    print(f"Lora successfully injected into {model.__class__.__name__}.")
+
+                break
+
+            return params, negation
+
+        if self.is_stable_lora():
+            injector_args = lora_args.copy()
+            injector_args = filter_dict(injector_args, keys=STABLE_LORA_KEYS)
+
+            SEARCH_CLASS = [torch.nn.Linear, torch.nn.Conv2d, torch.nn.Conv3d, torch.nn.Embedding]
+
+            injector_args.update({
+                "model": model,
+                "target_module": REPLACE_MODULES,
+                "search_class": SEARCH_CLASS,
+                "r": r,
+                "dropout": dropout,
+                "lora_bias": self.lora_bias
+            })
+
+            activator = self.lora_injector(**injector_args)
+            activator()
+
+        return params, negation
+
+    def add_lora_to_model(self, use_lora, model, replace_modules, dropout=0.0, lora_path='', r=16):
+
+        params = None
+        negation = None
+
+        lora_loader_args = self.get_lora_func_args(
+            lora_path,
+            use_lora,
+            model,
+            replace_modules,
+            r,
+            dropout,
+            self.lora_bias
+        )
+
+        self.load_lora(model, lora_path=lora_path, lora_loader_args=lora_loader_args)
+
+        if use_lora:
+           params, negation = self.do_lora_injection(
+            model, 
+            replace_modules, 
+            bias=self.lora_bias,
+            lora_loader_args=lora_loader_args,
+            dropout=dropout,
+            r=r
+        )
+        
+        params = model if params is None else params
+        return params, negation
+    
+
+    def deactivate_lora_train(self, models, deactivate=True):
+        """
+        Usage: Use before and after sampling previews.
+        Currently only available for Stable LoRA.
+        """
+        if self.is_stable_lora():
+            set_mode_group(models, not deactivate)
+
+    def save_cloneofsimo_lora(self, model, save_path, step, name, replace_modules):
+        conditions = [self.use_unet_lora, self.use_text_lora]
+        models = [model.unet, model.text_encoder]
+        replace_modules = [self.unet_replace_modules, self.text_encoder_replace_modules]
+
+        for model in models:
+            for i, condition in enumerate(conditions):
+                replace_modules = replace_modules[i]
+                name = 'text_encoder' if i == 1 else 'unet'
+                save_path = f"{save_path}/{step}_{name}.pt"
+                save_lora_weight(model, save_path, replace_modules)
+
+            train_patch_pipe(model, conditions[0], [conditions[1]])
+
+    def save_stable_lora(
+        self, 
+        model, 
+        step, 
+        name, 
+        save_path = '', 
+        save_for_webui=False,
+        only_for_webui=False
+    ):
+        import uuid
+
+        save_filename = f"{step}_{name}"
+        lora_metadata =  metadata = {
+        "stable_lora_text_to_video": "v1", 
+        "lora_name": name + "_" + uuid.uuid4().hex.lower()[:5]
+    }
+        save_lora(
+            model.unet,
+            model.text_encoder,
+            save_text_weights=self.use_text_lora,
+            output_dir=save_path,
+            lora_filename=save_filename,
+            lora_bias=self.lora_bias,
+            save_for_webui=self.save_for_webui,
+            only_webui=self.only_for_webui,
+            metadata=lora_metadata,
+            unet_dict_converter=convert_unet_state_dict,
+            text_dict_converter=convert_text_enc_state_dict_v20
+        )
+
+    def save_lora_weights(self, model: None, save_path: str ='',step: str = ''):
+        save_path = f"{save_path}/lora"
+        os.makedirs(save_path, exist_ok=True)
+
+        if self.is_cloneofsimo_lora():
+            if any([self.save_for_webui, self.only_for_webui]):
+                warnings.warn(
+                    """
+                    You have 'save_for_webui' enabled, but are using cloneofsimo's LoRA implemention.
+                    Only 'stable_lora' is supported for saving to a compatible webui file.
+                    """
+                )
+            self.save_cloneofsimo_lora(models, save_path, step, replace_modules)
+
+        if self.is_stable_lora():
+            name = 'lora_text_to_video'
+            self.save_stable_lora(model, step, name, save_path)


### PR DESCRIPTION
This adds support for training LoRA files that will be compatible for use with the [webui extension](https://github.com/kabachuha/sd-webui-text2video).

The webui compatible LoRA files ***are not*** a variant of cloneofsimo's or kohya's, but instead uses the official implementation by Microsoft (with added Conv3d support). This choice was purely based on ease of use and compatibility between different repositories / projects. You can find the Stable Diffusion compatible implementation [here.](https://github.com/ExponentialML/Stable-LoRA)

This will be done before the text2video webui support, but will be in progress asynchronously with this PR until I open a PR at the extension repository.

- [x] Create a LoRA Handler that allows for training multiple implementations `[cloneofsimo, stable_lora]`.
- [x] Ensure the cloneofsimo variant works with the new LoRA Handler (only tested Stable LoRA).
- [x] Test that loading and unloading LoRAs during training are not regressed in anyway.
- [x] Update instructions of `.yaml` files as needed.