### PR TITLE
Add temporal conv dropout

### DIFF
--- a/models/unet_3d_blocks.py
+++ b/models/unet_3d_blocks.py
@@ -276,6 +276,7 @@ class UNetMidBlock3DCrossAttn(nn.Module):
             TemporalConvLayer(
                 in_channels,
                 in_channels,
+                dropout=0.1
             )
         ]
         attentions = []
@@ -322,6 +323,7 @@ class UNetMidBlock3DCrossAttn(nn.Module):
                 TemporalConvLayer(
                     in_channels,
                     in_channels,
+                    dropout=0.1
                 )
             )
 
@@ -437,6 +439,7 @@ class CrossAttnDownBlock3D(nn.Module):
                 TemporalConvLayer(
                     out_channels,
                     out_channels,
+                    dropout=0.1
                 )
             )
             attentions.append(
@@ -575,6 +578,7 @@ class DownBlock3D(nn.Module):
                 TemporalConvLayer(
                     out_channels,
                     out_channels,
+                    dropout=0.1
                 )
             )
 
@@ -670,6 +674,7 @@ class CrossAttnUpBlock3D(nn.Module):
                 TemporalConvLayer(
                     out_channels,
                     out_channels,
+                    dropout=0.1
                 )
             )
             attentions.append(
@@ -803,6 +808,7 @@ class UpBlock3D(nn.Module):
                 TemporalConvLayer(
                     out_channels,
                     out_channels,
+                    dropout=0.1
                 )
             )
 


### PR DESCRIPTION
Adds a dropout of 0.1 to the temporal convolution layers. This help alleviate some of the constraints around training motion data.

Corrects https://github.com/ExponentialML/Text-To-Video-Finetuning/commit/95f25736bb0e7e19c246a7482221571298e470ce.