### PR TITLE
Enable Masked Training (WIP)

### DIFF
--- a/configs/v2/train_config.yaml
+++ b/configs/v2/train_config.yaml
@@ -71,6 +71,15 @@ text_encoder_lora_modules:
 # VRAM increases with higher rank, lower when decreased.
 lora_rank: 16
 
+# Enables the ability to do masked training. Advanced usage.
+# This enables the ability to sample multiple minutes of video.
+# Example
+# generation_frames_1: 8 frames
+# generation_frames_2: (Last 3 frames from generation_frames_1 + 5) + ((8 + 3) - last generation frames (3))
+# Continue for N amount of generation frames.
+# Combine and save.  
+enable_masked_train: False
+
 # Training data parameters
 train_data:
 


### PR DESCRIPTION
Currently still in testing, but this should in theory pave way for video continuation.

The primary code is here:

```py
if enable_masked_train:
        stop = random.randint(1, video_length // 2)    
        mask = torch.zeros_like(noisy_latents)
        mask[:, :, :stop, ...] = 1
        noisy_latents = noisy_latents * mask + (1. - mask) * noise
```

All we're doing is masking a random amount of initial noisy latents between `1, video_length // 2`, and then we use the rest of the non initial frames (random noise) as the new generation frames .

Ideally, this would mean that if we train the model this way, we can deterministically sample a start frame from timestep `t` to `0` during inference (so we get back the same frame), but allows the  new frames to understand the initial frames.

Theoretically, this would allow us to continuously render a video, creating long video generation.